### PR TITLE
Add IV hexagon graph (attempt 2)

### DIFF
--- a/src/components/PokemonCard.tsx
+++ b/src/components/PokemonCard.tsx
@@ -4,7 +4,7 @@ import caughtImage from "../images/caught.png";
 // @ts-ignore
 import uncaughtImage from "../images/uncaught.png";
 
-export function createPoly(health: number, attack: number, defense: number, sp_atk: number, sp_def: number, speed: number): string {
+function createPoly(health: number, attack: number, defense: number, sp_atk: number, sp_def: number, speed: number): string {
   return "polygon(50% " + (50 - Math.floor(health/31*50)) + "%, " + (50 + Math.floor(attack/31*50)) + "% " + (50 - Math.floor(attack/31*25)) + "%, " + (50 + Math.floor(defense/31*50)) + "% " + (50 + Math.floor(defense/31*25)) + "%, 50% " + (50 + Math.floor(speed/31*50)) + "%, " + (50 - Math.floor(sp_def/31*50)) + "% " + (50 + Math.floor(sp_def/31*25)) + "%, " + (50 - Math.floor(sp_atk/31*50)) + "% " + (50 - Math.floor(sp_atk/31*25)) + "%)"
 }
 

--- a/src/components/PokemonCard.tsx
+++ b/src/components/PokemonCard.tsx
@@ -4,6 +4,10 @@ import caughtImage from "../images/caught.png";
 // @ts-ignore
 import uncaughtImage from "../images/uncaught.png";
 
+export function createPoly(health: number, attack: number, defense: number, sp_atk: number, sp_def: number, speed: number): string {
+  return "polygon(50% " + (50 - Math.floor(health/31*50)) + "%, " + (50 + Math.floor(attack/31*50)) + "% " + (50 - Math.floor(attack/31*25)) + "%, " + (50 + Math.floor(defense/31*50)) + "% " + (50 + Math.floor(defense/31*25)) + "%, 50% " + (50 + Math.floor(speed/31*50)) + "%, " + (50 - Math.floor(sp_def/31*50)) + "% " + (50 + Math.floor(sp_def/31*25)) + "%, " + (50 - Math.floor(sp_atk/31*50)) + "% " + (50 - Math.floor(sp_atk/31*25)) + "%)"
+}
+
 const PokemonCard: React.FC<{
   //TODO: make partial node type for Pokemon from detailed page
   node: any;
@@ -66,7 +70,9 @@ const PokemonCard: React.FC<{
           style={{ height: "50px", marginLeft: "10px" }}
         />
         <div className="hexagon-wrapper">
-          <div className="hexagon">IVs</div>
+          <div className="hexagon">
+            <div className="ivgon" style={{ clipPath: createPoly(pokemon.hp, pokemon.atk, pokemon.def, pokemon.spAtk, pokemon.spDef, pokemon.speed) }}></div>
+          </div>
         </div>
       </div>
       <div className="info-card">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -70,6 +70,14 @@
   justify-content: center;
   align-items: center;
 }
+.ivgon {
+  width: 90px;
+  height: 100px;
+  background-color: #9ccdfa;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
 
 .hexagon-wrapper {
   flex: 1;


### PR DESCRIPTION
Displays a Pokémon's IVs by modifying the IV hexagon.
Removes the IV label as it may be covered up by the hexagon

Should work, but needs to be tested as I have no way to do that right now