### PR TITLE
Fix date picker displaying incorrect date depending on timezone

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { formatDate, isMatch, isValid } from "date-fns";
+import { addMinutes, formatDate, isMatch, isValid, subMinutes } from "date-fns";
 import { Link, navigate } from "gatsby";
 import React from "react";
 import DatePicker from "./DatePicker";
@@ -18,7 +18,9 @@ export default function Header({ date }: { date?: string }) {
           <Link to="/">Home</Link>
           <ModeToggle />
           {!!date && isMatch(date, "yyyy-MM-dd") && (
-            <DatePicker date={new Date(date)} onDateChange={handleDateChange} />
+            <DatePicker date={addMinutes(new Date(date), new Date().getTimezoneOffset())} onDateChange={handleDateChange} />
+            // addMinutes because local timezone is used for display for date picker
+            // This will adjust the date to be 00:00 on the local timezone
           )}
         </div>
       </nav>


### PR DESCRIPTION
The date object created by `new Date("yyyy-MM-dd")` is the 00:00 of that date on UTC+0, but date picker display that date using local timezone. 
This caused inconsistency between date displayed as selected and date that was actually selected on some timezone. For example, if the user selects August 6th, 2024, `new Date("2024-08-06")` would be sent to the date picker, which will be "2024-08-06 00:00:00". However, since that is "2024-08-05 18:00:00" in central standard time (UTC-6), the date picker displayed 2024-08-05 as selected instead of 2024-08-06.

I was unable to find a way to force react-day-picker to use UTC, so I employed a workaround solution where I adjusted the date sent to date picker to account for timezone offset.

Closes #40